### PR TITLE
add aarch to cf_binaries

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -16,7 +16,10 @@ cf_binaries:
     filename_tgz: cloudflared-stable-linux-arm.tgz
     filename_deb: cloudflared-stable-linux-arm.deb
     filename_rpm: cloudflared-stable-linux-arm.rpm
-
+  aarch64:
+    filename_tgz: cloudflared-stable-linux-arm.tgz
+    filename_deb: cloudflared-stable-linux-arm.deb
+    filename_rpm: cloudflared-stable-linux-arm.rpm
 ## common values
 systemd_target_dir: /etc/systemd/system/
 install_target_dir: /usr/bin


### PR DESCRIPTION
This fixes the install on AWS graviton and other instances that report
their achitecture as aarch64 instead of arm64