### PR TITLE
Remove unmanaged tunnels (by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible role "papanito.cloudflared" <!-- omit in toc -->
 
-![Ansible Role](https://img.shields.io/ansible/role/49833) ![Ansible Quality Score](https://img.shields.io/ansible/quality/49833) ![Ansible Role](https://img.shields.io/ansible/role/d/49833) ![GitHub issues](https://img.shields.io/github/issues/papanito/ansible-role-cloudflared) ![GitHub pull requests](https://img.shields.io/github/issues-pr/papanito/ansible-role-cloudflared) 
+![Ansible Role](https://img.shields.io/ansible/role/49833) ![Ansible Quality Score](https://img.shields.io/ansible/quality/49833) ![Ansible Role](https://img.shields.io/ansible/role/d/49833) ![GitHub issues](https://img.shields.io/github/issues/papanito/ansible-role-cloudflared) ![GitHub pull requests](https://img.shields.io/github/issues-pr/papanito/ansible-role-cloudflared)
 
 - [Authenticate the daemon](#authenticate-the-daemon)
 - [Requirements](#requirements)
@@ -13,7 +13,7 @@
 - [License](#license)
 - [Author Information](#author-information)
 
-This ansible role does download and install `cloudflared` on the host and optionally installs the [argo-tunnel] as a service. 
+This ansible role does download and install `cloudflared` on the host and optionally installs the [argo-tunnel] as a service.
 
 The role is made in a way that you can install multiple services in parallel - simply run the role several times with different parameters `service`, `hostname` and `url`.
 
@@ -77,6 +77,7 @@ These are all variables
 |`force_install`|Set to `true` if you want to re-install `cloudflared`. By default the assumption is that `cloudflared` is running as a service and automatically auto-updates.|`false`|
 |`tunnels`|[Mandatory] List of services, each one defining [Cloudflare parameters](#cloudflare-parameters)|-|
 |`do_legacy_cleanup`|Due to the changes of switching to [systemd-unit-template] you may need to cleanup the "legacy" stuff, if you used the role before.|`false`|
+|`remove_unmanaged_tunnels`|Remove services and configurations for tunnels not defined in `tunnels`|`true`|
 
 ### Cloudflare parameters
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,5 @@ force_install: False
 do_legacy_cleanup: False
 ssh_client_config: False
 ssh_client_config_group: ""
+
+remove_unmanaged_tunnels: True

--- a/tasks/configure-tunnels.yml
+++ b/tasks/configure-tunnels.yml
@@ -1,3 +1,12 @@
+- name: Find current tunnel config files
+  find:
+    paths: "{{ config_dir_tunnels }}"
+    patterns: '*.yml'
+  register: tunnel_configs
+- name: Remove unmanaged tunnels
+  include_tasks: remove-tunnel.yml
+  loop: "{{ tunnel_configs.files | map(attribute='path') | map('basename') | map('splitext') | map('first') }}"
+  when: remove_unmanaged_tunnels and (item not in tunnels)
 - name: Create config file for service '{{ item.key }}'
   template:
     src: config.yml.j2

--- a/tasks/remove-tunnel.yml
+++ b/tasks/remove-tunnel.yml
@@ -1,0 +1,9 @@
+- name: Disable service for unmanaged tunnel
+  systemd:
+    name: "{{ systemd_filename }}@{{ item }}"
+    enabled: no
+    state: stopped
+- name: Remove configuration for unmanaged tunnel
+  file:
+    path: "{{ config_dir_tunnels }}/{{ item }}.yml"
+    state: absent


### PR DESCRIPTION
This adds an option called `remove_unmanaged_tunnels`, which defaults to true. When it is true, if any tunnel configurations are found which aren't currently defined in `tunnels`, it will stop and disable any associated systemd service and remove the configurations file.