### PR TITLE
Restart tunnels if their configuration has changed

### DIFF
--- a/tasks/add-tunnel.yml
+++ b/tasks/add-tunnel.yml
@@ -1,0 +1,12 @@
+- name: Create config file for service '{{ item.key }}'
+  template:
+    src: config.yml.j2
+    dest: "{{ config_dir_tunnels }}/{{ item.key }}.yml"
+  register: tunnel_template
+- name: Restart systemd service {{ item.key }}
+  systemd:
+    name: "{{ systemd_filename }}@{{ item.key }}"
+    state: restarted
+    enabled: yes
+    no_block: no
+  when: tunnel_template.changed

--- a/tasks/add-tunnel.yml
+++ b/tasks/add-tunnel.yml
@@ -9,4 +9,4 @@
     state: restarted
     enabled: yes
     no_block: no
-  when: tunnel_template.changed
+  when: service_template.changed or tunnel_template.changed

--- a/tasks/configure-tunnels.yml
+++ b/tasks/configure-tunnels.yml
@@ -1,13 +1,3 @@
-- name: Create config file for service '{{ item.key }}'
-  template:
-    src: config.yml.j2
-    dest: "{{ config_dir_tunnels }}/{{ item.key }}.yml"
-  with_dict: "{{ tunnels }}"
-- name: Start systemd service {{ item.key }}
-  systemd:
-    name: "{{ systemd_filename }}@{{ item.key }}"
-    state: started
-    enabled: yes
-    daemon_reload: yes
-    no_block: no
+- name: Configure tunnels
+  include_tasks: add-tunnel.yml
   with_dict: "{{ tunnels }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -6,3 +6,9 @@
   template:
     src: cloudflared.service.j2
     dest: "{{ systemd_target_dir }}/{{ systemd_filename }}@.service"
+  register: service_template
+- name: Reload systemd
+  systemd:
+    daemon_reload: yes
+    no_block: no
+  when: service_template.changed


### PR DESCRIPTION
If an existing tunnel configuration gets rewritten, restart the tunnel. Also, only reload systemd when the unit file changes; it is not necessary to daemon-reload just to enable a new instance.