### PR TITLE
Add `no_logfile` option to tunnel configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ tunnels:
 |`proto_loglevel`|Specifies the verbosity of the HTTP/2 protocol logging. Any value below 'warn' is noisy and should only be used to debug low - level performance issues and protocol quirks - see [docu](https://developers.cloudflare.com/argo-tunnel/reference/arguments/#proto-loglevel)|`info`|
 |`retries`|Maximum number of retries for connection/protocol errors. Retries use exponential backoff (retrying at 1, 2, 4, 8, 16 seconds by default) so increasing this value significantly is not recommended - see [docu](https://developers.cloudflare.com/argo-tunnel/reference/arguments/#retries)|`5`|
 |`no_chunked_encoding`|Disables chunked transfer encoding; useful if you are running a WSGI server - see [docu](https://developers.cloudflare.com/argo-tunnel/reference/arguments/#no-chunked-encoding)|`false`|
+|`no_logfile`|Disables writing a logfile for cloudflared - it will still log to the journal|`false`|
 
 ### SSH Client config
 

--- a/templates/config.yml.j2
+++ b/templates/config.yml.j2
@@ -1,7 +1,9 @@
 hostname: {{ item.value.hostname }}
 url: {{ item.value.url }}
-logfile: /var/log/cloudflared_{{ item.key }}.log
 
+{% if not (item.value.no_logfile | default(False)) %}
+logfile: /var/log/cloudflared_{{ item.key }}.log
+{% endif %}
 {% if item.value.lb_pool is defined %}
 lb-pool: {{ item.value.lb_pool }}
 {% endif %}


### PR DESCRIPTION
This is handy, if, like me, you'd prefer just to read the logs out of the systemd journal.