### PR TITLE
Add ability to install cloudflared on Init-V Systems like amazonlinux1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - [License](#license)
 - [Author Information](#author-information)
 
-This ansible role does download and install `cloudflared` on the host and optionally installs the [argo-tunnel] as a service. 
+This ansible role does download and install `cloudflared` on the host and optionally installs the [argo-tunnel] as a service.
 
 The role is made in a way that you can install multiple services in parallel - simply run the role several times with different parameters `service`, `hostname` and `url`.
 
@@ -70,6 +70,7 @@ These are all variables
 |---------|-----------|-------------|
 |`systemd_user`|User for systemd service|`backup`|
 |`systemd_group`|Group for systemd service|`backup`|
+|`use_system_v`|Use System-V instead of systemd|`false`|
 |`download_baseurl`|Base url for `cloudflare` binaries|https://bin.equinox.io/c/VdrWdbjqyF/|
 |`cert_location`|Location of the certificate to be copied - see [Authenticate the daemon](#authenticate-the-daemon)|-|
 |`cert_content`|Content of the certificate to be copied - see [Authenticate the daemon](#authenticate-the-daemon)|-|
@@ -80,6 +81,8 @@ These are all variables
 |`tunnels`|[Mandatory] List of services, each one defining [Cloudflare parameters](#cloudflare-parameters)|-|
 |`do_legacy_cleanup`|Due to the changes of switching to [systemd-unit-template] you may need to cleanup the "legacy" stuff, if you used the role before.|`false`|
 |`remove_unused_tunnels`|Removes unused tunnels, means tunnels running but not listed in `tunnels`.|`false`|
+|`remove_setup_certificate`|Remove cert.pem after installing the service|`false`|
+
 
 ### Cloudflare parameters
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for cloudflared
 systemd_user: root
 systemd_group: root
-use_systemv: False
+use_system_v: False
 remove_setup_certificate: False
 
 download_baseurl: https://bin.equinox.io/c/VdrWdbjqyF/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 # defaults file for cloudflared
 systemd_user: root
 systemd_group: root
+use_systemv: False
+remove_setup_certificate: False
 
 download_baseurl: https://bin.equinox.io/c/VdrWdbjqyF/
 download_folder: ./download

--- a/tasks/add-tunnel.yml
+++ b/tasks/add-tunnel.yml
@@ -8,5 +8,10 @@
     name: "{{ systemd_filename }}@{{ item.key }}"
     state: restarted
     enabled: yes
-    no_block: no
-  when: service_template.changed or tunnel_template.changed
+  when: (service_template.changed or tunnel_template.changed) and not use_system_v
+- name: Restart systemv service {{ item.key }}
+  ansible.builtin.service:
+    name: "{{ systemd_filename }}-{{ item.key }}"
+    state: restarted
+    enabled: yes
+  when: (service_template.changed or tunnel_template.changed) and use_system_v

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,10 +1,52 @@
-- name: Install cloudflared service for service '{{ tunnel_name }}''
+- name: Define required variables for configure
+  set_fact:
+    tunnel_name: "{{ item.key }}"
+
+- name: Install cloudflared service for service '{{ tunnel_name }}' in systemd
   template:
     src: cloudflared.service.j2
     dest: "{{ systemd_target_dir }}/{{ systemd_filename }}@.service"
   register: service_template
+  when: not use_system_v
 - name: Reload systemd
   systemd:
     daemon_reload: yes
     no_block: no
-  when: service_template.changed
+  when: service_template.changed and not use_system_v
+
+- name: Install cloudflared service for service '{{ tunnel_name }}' in System-V
+  template:
+    src: cloudflared.systemv.j2
+    dest: "/etc/init.d/{{ systemd_filename }}-{{ tunnel_name }}"
+    owner: root
+    group: root
+    mode: 0755
+  register: service_template
+  when: use_system_v
+
+- name: Link Stop-Script to /etc/init.d/"{{ systemd_filename }}-{{ tunnel_name }}"
+  file:
+    src: "/etc/init.d/{{ systemd_filename }}-{{ tunnel_name }}"
+    path: "/etc/{{ item_runlevel }}/K01{{ systemd_filename }}-{{ tunnel_name }}"
+    state: link
+  with_items:
+    - rc0.d
+    - rc1.d
+    - rc6.d
+  loop_control:
+    loop_var: item_runlevel
+  when: service_template.changed and use_system_v
+
+- name: "Link Start-Script /etc/init.d/{{ systemd_filename }}-{{ tunnel_name }}"
+  file:
+    src: "/etc/init.d/{{ systemd_filename }}-{{ tunnel_name }}"
+    path: "/etc/{{ item_runlevel }}/S99{{ systemd_filename }}-{{ tunnel_name }}"
+    state: link
+  with_items:
+    - rc2.d
+    - rc3.d
+    - rc4.d
+    - rc5.d
+  loop_control:
+    loop_var: item_runlevel
+  when: service_template.changed and use_system_v

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,32 +5,46 @@
     daemon_location: "{{ install_target_dir }}/cloudflared"
     cf_binary_filename: "{{ cf_binaries[ansible_machine].filename_tgz }}"
     systemd_filename: "cloudflared"
+
 - name: Cleanup legacy stuff
   include_tasks: cleanup.yml
   with_dict: "{{ tunnels }}"
   when: do_legacy_cleanup
+
 - name: Populate service facts
   service_facts:
+
 - name: Setting tunnels_available
   set_fact:
-    tunnels_available: "{{ ansible_facts.services | select('match', 'cloudflared@(.+).service') | \
-                           map('regex_replace', 'cloudflared@', '') | map('regex_replace', '.service' '') | list }}"
+    tunnels_available: "{{ ansible_facts.services | select('match', 'cloudflared@(.+).service|cloudflared-(.*)') | \
+                           map('regex_replace', 'cloudflared@|cloudflared-', '') | map('regex_replace', '.service' '') | list }}"
+
 - name: Setting tunnels to remove
   set_fact:
     tunnels_to_remove: "{{ tunnels_available | difference(tunnels) }}"
+
 - name: Remove unused tunnels
   include_tasks: remove-tunnels.yml
   with_items: "{{ tunnels_to_remove }}"
   when: remove_unused_tunnels
+
 - name: Download and install cloudflared
   include_tasks: install.yml
+
 - name: Install cloudflared
   include_tasks: configure.yml
+  with_dict: "{{ tunnels }}"
   when: not install_only
+
 - name: Configure tunnels
   include_tasks: configure-tunnels.yml
   when: not install_only
+
 - name: Add ssh proxy for all servers in the ssh client config
   include_tasks: ssh-client-config.yml
   loop: "{{ groups['servers'] }}"
   when: ssh_client_config
+
+- name: Remove setup certificate
+  include_tasks: remove-setup-certificate.yml
+  when: remove_setup_certificate

--- a/tasks/remove-setup-certificate.yml
+++ b/tasks/remove-setup-certificate.yml
@@ -1,0 +1,4 @@
+- name: Removing {{ config_dir }}/{{ cert_name }}
+  file:
+    path: "{{ config_dir }}/{{ cert_name }}"
+    state: absent

--- a/tasks/remove-tunnels.yml
+++ b/tasks/remove-tunnels.yml
@@ -5,15 +5,57 @@
     enabled: no
     daemon_reload: yes
     no_block: no
+  when: not use_system_v
+
+- name: Stop service "{{ systemd_filename }}-{{ item }}"
+  ansible.builtin.service:
+    name: "{{ systemd_filename }}-{{ item }}"
+    state: stopped
+  when: use_system_v
+
 - name: Delete config file for tunnel '{{ item }}'
   file:
     state: absent
     path: "{{ config_dir_tunnels }}/{{ item }}.yml"
+
 - name: Delete logfile for tunnel '{{ item }}'
   file:
     state: absent
     path: "/var/log/cloudflared_{{ item }}.log"
+
 - name: Delete systemd service file for tunnel '{{ item }}'
   file:
     state: absent
     path: "{{ systemd_filename }}@{{ item }}"
+  when: not use_system_v
+
+- name: Delete Link in runlevel directory to /etc/init.d/"{{ systemd_filename }}-{{ item }}"
+  file:
+    path: "/etc/{{ item_runlevel }}/K01{{ systemd_filename }}-{{ item }}"
+    state: absent
+  with_items:
+    - rc0.d
+    - rc1.d
+    - rc6.d
+  loop_control:
+    loop_var: item_runlevel
+  when: use_system_v
+
+- name: "Delete Link in runlevel directory to /etc/init.d/{{ systemd_filename }}-{{ item }}"
+  file:
+    path: "/etc/{{ item_runlevel }}/S99{{ systemd_filename }}-{{ item }}"
+    state: absent
+  with_items:
+    - rc2.d
+    - rc3.d
+    - rc4.d
+    - rc5.d
+  loop_control:
+    loop_var: item_runlevel
+  when: use_system_v
+
+- name: Delete systemv service file for tunnel '{{ item }}'
+  file:
+    state: absent
+    path: /etc/init.d/"{{ systemd_filename }}-{{ item }}"
+  when: use_system_v

--- a/templates/cloudflared.systemv.j2
+++ b/templates/cloudflared.systemv.j2
@@ -1,0 +1,83 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          cloudflared tunnel for {{ tunnel_name}}
+# Required-Start:    $local_fs $network $named $time $syslog
+# Required-Stop:     $local_fs $network $named $time $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Description:       cloudflared tunnel for {{ tunnel_name }}
+### END INIT INFO
+
+SCRIPT="cloudflared tunnel --config {{ config_dir_tunnels }}/{{ tunnel_name }}.yml"
+RUNAS={{ systemd_user }}
+
+PIDFILE=/var/run/{{ systemd_filename }}_{{ tunnel_name }}.pid
+LOGFILE=/var/log/{{ systemd_filename }}_{{ tunnel_name }}.log
+
+start() {
+  if [ -f $PIDFILE ] && [ -s $PIDFILE ] && kill -0 $(cat $PIDFILE); then
+    echo 'Service already running' >&2
+    return 1
+  fi
+  echo 'Starting service…' >&2
+  local CMD="$SCRIPT &> \"$LOGFILE\" & echo \$!"
+  su -c "$CMD" $RUNAS > "$PIDFILE"
+ # Try with this command line instead of above if not workable
+ # su -s /bin/sh $RUNAS -c "$CMD" > "$PIDFILE"
+
+  sleep 2
+  PID=$(cat $PIDFILE)
+    if pgrep -u $RUNAS -f "$SCRIPT" > /dev/null
+    then
+      echo "$SCRIPT is now running, the PID is $PID"
+    else
+      echo ''
+      echo "Error! Could not start $SCRIPT!"
+    fi
+}
+
+stop() {
+  if [ ! -f "$PIDFILE" ] || ! kill -0 $(cat "$PIDFILE"); then
+    echo 'Service not running' >&2
+    return 1
+  fi
+  echo 'Stopping service…' >&2
+  kill -15 $(cat "$PIDFILE") && rm -f "$PIDFILE"
+  echo 'Service stopped' >&2
+}
+
+status() {
+    printf "%-50s" "Checking {{ systemd_filename }}-{{ tunnel_name }}..."
+    if [ -f $PIDFILE ] && [ -s $PIDFILE ]; then
+        PID=$(cat $PIDFILE)
+            if [ -z "$(ps axf | grep ${PID} | grep -v grep)" ]; then
+                printf "%s\n" "The process appears to be dead but pidfile still exists"
+            else
+                echo "Running, the PID is $PID"
+            fi
+    else
+        printf "%s\n" "Service not running"
+    fi
+}
+
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  status)
+    status
+    ;;
+  uninstall)
+    uninstall
+    ;;
+  restart)
+    stop
+    start
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|status|restart}"
+esac

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,6 +19,7 @@ cf_binaries:
 
 ## common values
 systemd_target_dir: /etc/systemd/system/
+initv_target_dir: /etc/init.d/
 install_target_dir: /usr/bin
 config_dir: /etc/cloudflared
 config_dir_tunnels: "{{ config_dir }}"


### PR DESCRIPTION
Hi we have the problem that we still have amazonlinux1 systems in the AWS and are in the need of a role that can install cloudflared on amazonlinux1 which is without systemd and amazonlinux2. So i thought that it would be a good idea to extend your role to be able to accomplish that rather than creating a new one.

It would be great if you would consider merging this request and updating the role on ansible-glaxy.

regards
Manuel 