### PR TITLE
feat: add new parameter `cf_warp_routing`

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ These are parameters required to create the system service
 |`cf_cert_location`|Location of the certificate to be copied - see [Authenticate the daemon](#authenticate-the-daemon)|-|
 |`cf_cert_content`|Content of the certificate to be copied - see [Authenticate the daemon](#authenticate-the-daemon)|-|
 |`cf_tunnels`|[Mandatory] List of tunnel-services, each one defining [Cloudflare parameters](#cloudflare-parameters)|-|
-|`cf_credentials_dir`|Location where put [Credential files]||
+|`cf_warp_routing`|Allow users to connect to internal services using WARP, details see [warp-routing]|`false`|
 
 It's recommended to use [named tunnels] for `cf_tunnels` which require [Cloudflare named tunnel parameters](#cloudflare-named-tunnel-parameters) but you can also use [Cloudflare legacy tunnel parameters](#cloudflare-legacy§-tunnel-parameters)
 
@@ -330,3 +330,4 @@ Written by [Papanito](https://wyssmann.com) - [Gitlab](https://gitlab.com/papani
 [cli-args]: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configuration/config
 [authenticate-the-cloudflare-daemon]: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/setup
 [systemd-unit-template]: https://fedoramagazine.org/systemd-template-unit-files/ssh-guide-client
+[warp-routing]: https://developers.cloudflare.com/cloudflare-one/tutorials/warp-to-tunnel#configure-and-run-the-tunnel

--- a/templates/config.yml.j2
+++ b/templates/config.yml.j2
@@ -2,6 +2,13 @@
 {% if cf_tunnel.value.hostname is defined %}
 hostname: {{ cf_tunnel.value.hostname }}
 url: {{ cf_tunnel.value.url }}
+{% elif (cf_tunnel.value.cf_warp_routing | default(False)) %}
+tunnel: {{ cf_tunnel.key }}
+credentials-file: {{ cf_credentials_dir }}/{{ cf_tunnel.value.tunnel_id }}.json
+warp-routing:
+  enabled: true
+ingress:
+  {{ cf_tunnel.value.ingress | to_nice_yaml(indent=2) | indent(2) }}
 {% else %}
 tunnel: {{ cf_tunnel.key }}
 credentials-file: {{ cf_credentials_dir }}/{{ cf_tunnel.value.tunnel_id }}.json
@@ -47,4 +54,8 @@ retries: {{ cf_tunnel.value.retries }}
 {% endif %}
 {% if cf_tunnel.value.no_chunked_encoding is defined %}
 no-chunked-encoding: {{ cf_tunnel.value.no_chunked_encoding }}
+{% endif %}
+{% if (cf_tunnel.value.cf_warp_routing | default(False)) and  cf_tunnel.value.hostname is defined %}
+warp-routing:
+  enabled: true
 {% endif %}


### PR DESCRIPTION
You can also use Cloudflare Tunnel to connect any service that relies
on a TCP-based protocol to Cloudflare's network. Users in your organization can
then reach the service by enrolling into your organization's Cloudflare for Teams
account and using the WARP agent.