### PR TITLE
Cloudflare CIDR rules and APT installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ The following parameters control the installation and/or un-installation
 |`cf_remove_setup_certificate`|Remove cert.pem after installing the service|`false`|
 |`cf_credential_file_base`|Folder where to place credential files|`/root/.cloudflared/`|
 |`cf_config_dir`|Folder where to place cloudflare configuration files|`/etc/cloudflared`|
+|`cf_os_package_enable`|Use OS packaging system and Cloudflare package repository (currently just Debian/Ubuntu)|`false`|
+|`cf_repository_key_url`|If cf_os_package_enable is true, url of the GPG key for the apt repository | `https://pkg.cloudflare.com/pubkey.gpg` |
+|`cf_repository`|If cf_os_package_enable is true, url for the Cloudflare apt repository | `deb http://pkg.cloudflare.com/ {{ ansible_distribution_release }} main` |
 
 ### Cloudflared service parameters
 
@@ -157,6 +160,8 @@ It's recommended to use [named tunnels] for `cf_tunnels` which require [Cloudfla
         routes:
           dns:
           - "{{ inventory_hostname }}"
+          cidr:
+          - "192.168.42.0/24"
         account_tag:  !vault....
         tunnel_secret: !vault....
         tunnel_id: !vault....
@@ -166,7 +171,7 @@ It's recommended to use [named tunnels] for `cf_tunnels` which require [Cloudfla
           - hostname: hello.mycompany.com
             service: hello_world
           - hostname: ssh.mycompany.com
-            service: ssh://localhost:22  - service: http_status:404
+            service: ssh://localhost:22
           - service: http_status:404
 ```
 
@@ -180,9 +185,15 @@ The `key` of the tunnel shall match the of `tunnel_id`.
 |`ingress`|[Mandatory] [ingress rules] for the tunnel|-|
 |`routes`|List of routes which shall be created. It allows a list for `dns`-routes at the moment (see example above)|`-`|
 
-#### DNS Routes
+#### Routes
+
+##### DNS
 
 `dns` routes expect a list of `CNAME`'s to be created as [described here¨](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/routing-to-tunnel/dns). If the `CNAME` already exists the task will be skipped but no error thrown. Also only add `CNAME` not a FQDN as the `FQDN` is determined by `cloudlfared`.
+
+##### Private Network
+
+`private network` routes expect a list of `CIDR`'s to be created as [described here](https://developers.cloudflare.com/cloudflare-one/tutorials/warp-to-tunnel). The playbook loop on the list to execute `cloudflared tunnel route ip add {{ cf_cidr_entry }} {{ cf_tunnel.key }}`. If the `CIDR` already exists, an error will thrown but ignored.
 
 ### Cloudflare single service parameters
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,6 @@ cf_ssh_client_config_group: ""
 
 cf_credentials_dir: "/root/.cloudflared/"
 
-cf_os_package_enable: true
+cf_os_package_enable: false
 cf_repository_key_url: "https://pkg.cloudflare.com/pubkey.gpg"
 cf_repository: "deb http://pkg.cloudflare.com/ {{ ansible_distribution_release }} main"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,7 @@ cf_ssh_client_config: False
 cf_ssh_client_config_group: ""
 
 cf_credentials_dir: "/root/.cloudflared/"
+
+cf_os_package_enable: true
+cf_repository_key_url: "https://pkg.cloudflare.com/pubkey.gpg"
+cf_repository: "deb http://pkg.cloudflare.com/ {{ ansible_distribution_release }} main"

--- a/tasks/create_routes.yml
+++ b/tasks/create_routes.yml
@@ -5,3 +5,11 @@
     loop_var: cf_dns_entry
   tags:
   - cf_routing
+
+- name: Create CIDR routing entries
+  include_tasks: create_routes_cidr.yml
+  loop: "{{ cf_tunnel.value.routes.cidr }}"
+  loop_control:
+    loop_var: cf_cidr_entry
+  tags:
+    - cf_routing

--- a/tasks/create_routes.yml
+++ b/tasks/create_routes.yml
@@ -13,3 +13,4 @@
     loop_var: cf_cidr_entry
   tags:
     - cf_routing
+  when: cf_tunnel.value.routes.cidr is defined

--- a/tasks/create_routes_cidr.yml
+++ b/tasks/create_routes_cidr.yml
@@ -1,0 +1,8 @@
+---
+- name: Create CIDR entry '{{ cf_cidr_entry }}' for tunnel '{{ cf_tunnel.key }}'
+  command: cloudflared tunnel route ip add {{ cf_cidr_entry }} {{ cf_tunnel.key }}
+  register: create_cidr
+  ignore_errors: true
+- name: Show command output
+  ansible.builtin.debug:
+    msg: "{{ create_cidr.stdout }}{{ create_cidr.stderr }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,14 +1,31 @@
-- name: Check if file '{{ daemon_location }}' exists
-  ansible.builtin.stat:
-    path: "{{ daemon_location }}"
-    checksum_algorithm: sha256
-  register: stat_result
-- name: Unarchive {{ cf_download_baseurl }}/{{ cf_binary_filename }} to {{ cf_install_target_dir }}
-  unarchive:
-    src: "{{ cf_download_baseurl }}/{{ cf_binary_filename }}"
-    dest: "{{ cf_install_target_dir }}"
-    remote_src: yes
-  when: not stat_result.stat.exists or cf_force_install
+- block:
+  - name: Add Cloudflare repository GPG key
+    ansible.builtin.apt_key:
+      url: "{{ cf_repository_key_url }}"
+      state: present
+  - name: Add Cloudflare repository to apt sources list
+    ansible.builtin.apt_repository:
+      repo: "{{ cf_repository }}"
+      state: present
+  - name: Install Cloudflared
+    ansible.builtin.apt:
+      update_cache: yes
+      name: cloudflared
+      state: latest
+  when: (ansible_distribution == "Debian" or ansible_distribution == "Ubuntu") and cf_os_package_enable
+- block:
+  - name: Check if file '{{ daemon_location }}' exists
+    ansible.builtin.stat:
+      path: "{{ daemon_location }}"
+      checksum_algorithm: sha256
+    register: stat_result
+  - name: Unarchive {{ cf_download_baseurl }}/{{ cf_binary_filename }} to {{ cf_install_target_dir }}
+    unarchive:
+      src: "{{ cf_download_baseurl }}/{{ cf_binary_filename }}"
+      dest: "{{ cf_install_target_dir }}"
+      remote_src: yes
+    when: not stat_result.stat.exists or cf_force_install
+  when: (ansible_distribution != "Debian" and ansible_distribution != "Ubuntu") or not cf_os_package_enable
 - name: Create {{ cf_config_dir }} if it does not exist
   ansible.builtin.file:
     path: "{{ cf_config_dir }}"


### PR DESCRIPTION
CHANGELOG:
  * Add task to add private network to a tunnel:
  `cloudflared tunnel route ip add 100.64.0.0/10 8e343b13-a087-48ea-825f-9783931ff2a5`
  * Add capability to install cloudflared with Debian/Ubuntu Cloudflare repository
