### PR TITLE
feat: added links for aarch64

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -16,6 +16,10 @@ cf_binaries:
     filename_tgz: cloudflared-stable-linux-arm.tgz
     filename_deb: cloudflared-stable-linux-arm.deb
     filename_rpm: cloudflared-stable-linux-arm.rpm
+  aarch64:
+    filename_tgz: cloudflared-stable-linux-arm64.tgz
+    filename_deb: cloudflared-stable-linux-arm64.deb
+    filename_rpm: cloudflared-stable-linux-arm64.rpm
 
 ## common values
 cf_systemd_target_dir: /etc/systemd/system/


### PR DESCRIPTION
When running on Ubuntu 20.10 64-bit on a Raspberry Pi 4, install fails because of an unknown arch (aarch64).

Cloudflare does have a download on their page for ARM64 which works with the Pi 4; this PR adds the filename to the variables file.