### PR TITLE
fix: Default values for Cloudflare apt repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ The following parameters control the installation and/or un-installation
 |`cf_config_dir`|Folder where to place cloudflare configuration files|`/etc/cloudflared`|
 |`cf_os_package_enable`|Use OS packaging system and Cloudflare package repository (currently just Debian/Ubuntu)|`false`|
 |`cf_repository_key_url`|If cf_os_package_enable is true, url of the GPG key for the apt repository | `https://pkg.cloudflare.com/pubkey.gpg` |
-|`cf_repository`|If cf_os_package_enable is true, url for the Cloudflare apt repository | `deb http://pkg.cloudflare.com/ {{ ansible_distribution_release }} main` |
+|`cf_repository_key_install_path`|If cf_os_package_enable is true, path where to instal the GPG key for the apt repository | `/usr/share/keyrings/cloudflare-main.gpg` |
+|`cf_repository`|If cf_os_package_enable is true, url for the Cloudflare apt repository | `deb [signed-by={{ cf_repository_key_install_path }}] https://pkg.cloudflare.com/cloudflared {{ ansible_distribution_release }} main` |
 |`cf_binary_name`|Name of the cloudflare daemon binary - change only if you know what you are doing|`cloudflared`|
 
 ### Cloudflared service parameters

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,5 +16,6 @@ cf_ssh_client_config_group: ""
 cf_credentials_dir: "/root/.cloudflared/"
 
 cf_os_package_enable: false
-cf_repository_key_url: "https://pkg.cloudflare.com/pubkey.gpg"
-cf_repository: "deb http://pkg.cloudflare.com/ {{ ansible_distribution_release }} main"
+cf_repository_key_url: https://pkg.cloudflare.com/cloudflare-main.gpg
+cf_repository_key_install_path: /usr/share/keyrings/cloudflare-main.gpg
+cf_repository: "deb [signed-by={{ cf_repository_key_install_path }}] https://pkg.cloudflare.com/cloudflared {{ ansible_distribution_release }} main"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,6 +2,7 @@
   - name: Add Cloudflare repository GPG key
     ansible.builtin.apt_key:
       url: "{{ cf_repository_key_url }}"
+      keyring: "{{ cf_repository_key_install_path }}"
       state: present
   - name: Add Cloudflare repository to apt sources list
     ansible.builtin.apt_repository:


### PR DESCRIPTION
Fixes #58 by:
- Updating the default URLs for the apt gpg key and repository to the correct values,
- Adding the `signed-by` option to the APT repository configurable with `cf_repository_key_install_path`.